### PR TITLE
Check video duration before generate thumbnails

### DIFF
--- a/test/vice_thumbnails_tests.erl
+++ b/test/vice_thumbnails_tests.erl
@@ -1,0 +1,26 @@
+-module(vice_thumbnails_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+hms_test_() ->
+  {setup,
+   fun() ->
+     vice:start(),
+     ok
+   end,
+   fun(_) ->
+     application:stop(vice),
+     application:stop(poolgirl),
+     ok
+   end,
+   [
+    fun() ->
+        ?assertEqual(
+          {error, 22.233},
+          vice:thumbnails("test/erlang.mp4", "webvtttest", [{out_path, "test/thumbnails"}, {assets_path, ""}, {every, 30}])
+        ),
+        ?assertMatch(
+          {async, _},
+          vice:thumbnails("test/erlang.mp4", "webvtttest", [{out_path, "test/thumbnails"}, {assets_path, ""}, {every, 1}])
+        )
+    end
+   ]}.


### PR DESCRIPTION
This change add a check on video duration before generating thumbnails.
Prevent generating an empty thumbnails sprite.

https://github.com/G-Corp/vice/issues/12