### PR TITLE
Fix error on thumbnail vtt generation

### DIFF
--- a/src/vice_thumbnails.erl
+++ b/src/vice_thumbnails.erl
@@ -248,7 +248,7 @@ vvtline(N, L, C, Start, Every, Duration, SpriteFile, Width, Height, Lines, Colum
   {NL, NC} = new_position(L, C, Lines, Columns),
   vvtline(N - 1, NL, NC, End, Every, Duration, SpriteFile, Width, Height, Lines, Columns, IO).
 
-new_position(L, C, _Lines, Columns) when C == Columns ->
+new_position(L, C, _Lines, Columns) when C == Columns - 1 ->
   {L + 1, 0};
 new_position(L, C, _Lines, _Columns) ->
   {L, C + 1}.


### PR DESCRIPTION
When a vtt file is generated from a sprite, the counter of columns is wrong and refer some positions out of the sprite.