### PR TITLE
Raise minimum required CMake to 3.5 for modern toolchains

### DIFF
--- a/c_src/CMakeLists.txt
+++ b/c_src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 project(VICE_FACEDETECT)
 if(NOT WIN32)
   string(ASCII 27 Esc)


### PR DESCRIPTION
This updates c_src/CMakeLists.txt to require CMake >= 3.5 so the project configures with current CMake versions.

- Keeps facedetect module optional